### PR TITLE
Commented out second query method, changed orcid substring length, partial fix for shiny x-axis issue

### DIFF
--- a/Rorcid_Crossref_Authors.R
+++ b/Rorcid_Crossref_Authors.R
@@ -174,8 +174,6 @@ my_query <- glue('ringgold-org-id:', ringgold_id,
 # keep in mind that ROR ID and organization name are strings and need double quotes inside the 
 # single quotes used here for concatenation
 # replace these  example lines from Temple University carefully with ones you are interested in 
-my_query <- glue('ringgold-org-id:', '6558', 
-                 ' OR ringgold-org-id:', '43297',
 # and uncomment the below when you're done.
 # my_query <- glue('ringgold-org-id:', '6558', 
 #                 ' OR ringgold-org-id:', '43297',

--- a/Rorcid_Crossref_Authors.R
+++ b/Rorcid_Crossref_Authors.R
@@ -176,18 +176,21 @@ my_query <- glue('ringgold-org-id:', ringgold_id,
 # replace these  example lines from Temple University carefully with ones you are interested in 
 my_query <- glue('ringgold-org-id:', '6558', 
                  ' OR ringgold-org-id:', '43297',
-                 ' OR ringgold-org-id:', '83908',
-                 ' OR grid-org-id:', 'grid.264727.2', 
-                 ' OR grid-org-id:', 'grid.469246.b', 
-                 ' OR grid-org-id:', 'grid.460938.0', 
-                 ' OR ror-org-id:"', 'https://ror.org/00kx1jb78', 
-                 '" OR ror-org-id:"', 'https://ror.org/04zzmzt85',
-                 '" OR ror-org-id:"', 'https://ror.org/03savr706', 
-                 '" OR email:*', '@temple.edu', 
-                 ' OR email:*', '@tuj.temple.edu', 
-                 ' OR affiliation-org-name:"', 'Temple University',
-                 '" OR affiliation-org-name:"', 'Temple Ambler',
-                 '" OR affiliation-org-name:"', 'Temple Japan', '"')
+# and uncomment the below when you're done.
+# my_query <- glue('ringgold-org-id:', '6558', 
+#                 ' OR ringgold-org-id:', '43297',
+#                 ' OR ringgold-org-id:', '83908',
+#                 ' OR grid-org-id:', 'grid.264727.2', 
+#                 ' OR grid-org-id:', 'grid.469246.b', 
+#                 ' OR grid-org-id:', 'grid.460938.0', 
+#                 ' OR ror-org-id:"', 'https://ror.org/00kx1jb78', 
+#                '" OR ror-org-id:"', 'https://ror.org/04zzmzt85',
+#                '" OR ror-org-id:"', 'https://ror.org/03savr706', 
+#                '" OR email:*', '@temple.edu', 
+#                 ' OR email:*', '@tuj.temple.edu', 
+#                 ' OR affiliation-org-name:"', 'Temple University',
+#                '" OR affiliation-org-name:"', 'Temple Ambler',
+#                '" OR affiliation-org-name:"', 'Temple Japan', '"')
 
 # get the counts
 ##### TIME: this may hang a bit if institution has many ORCID ID holders(e.g. for Temple University's data [~3500 IDs], this took a few seconds)

--- a/Rorcid_Crossref_Authors.R
+++ b/Rorcid_Crossref_Authors.R
@@ -755,7 +755,7 @@ authlist_all <- auths_merge %>%
 
 # add some columns to authlist_all to help with this deduplicating
 authlist_all$orcid_coauth <- with(authlist_all, 
-                                  ifelse(is.na(ORCID),'',str_sub(ORCID, 18, 37))
+                                  ifelse(is.na(ORCID),'',str_sub(ORCID, 19, 37))
 )
 
 # fullname identifier for the home author, striped of punctuation and whitespace

--- a/shiny-visualization/app.R
+++ b/shiny-visualization/app.R
@@ -206,7 +206,7 @@ server <- function(input, output, session) {
                      tickmode = "linear",
                      tick0 = 0,
                      dtick = 1,
-                     fixedrange=TRUE),
+                     autorange = TRUE),
         margin = list(l = 120)  # Adjust left margin for longer y-axis labels
       )
   })

--- a/shiny-visualization/app.R
+++ b/shiny-visualization/app.R
@@ -205,7 +205,8 @@ server <- function(input, output, session) {
         xaxis = list(title = "",
                      tickmode = "linear",
                      tick0 = 0,
-                     dtick = 1),
+                     dtick = 1,
+                     fixedrange=TRUE),
         margin = list(l = 120)  # Adjust left margin for longer y-axis labels
       )
   })


### PR DESCRIPTION
For issue #33 . To maintain consistency within the file (line 289 has the second method commented out by default), maintain ease of use, and to prevent overriding of user data in my_query with the Temple University example data, I have commented out the second (complex) query method on line 191. This should make it so that a user can run the entire R script file once they've defined their organizational variables at the top and not get any errors as the script attempts to use data organization functions on an empty dataframe.

For issue #34 , added fixedrange=TRUE to the Plotly graph code in the Shiny app, this prevents the graph from showing or being moved anywhere outside its defined range, _but_ Pull request #39 (Autorange=TRUE) is a better solution. I've updated the file in my pull request to reflect this better solution and to not cause any merge conflicts between these two solutions.

For issue #36 , in the code, Orcid co-author IDs were taken as a subset from a longer string. The length of this subset included a slash (/) at the beginning of the ID number, which prevented the Orcid IDs from being 'read' and generating location data in the output spreadsheet. I changed the the start point of the string subset from 18 characters in, to 19 characters in. This allows location data to be populated for co-authors currently employed at a university institution who have an Orcid account.